### PR TITLE
Update train_semseg.py and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Download 3D indoor parsing dataset (**S3DIS**) [here](http://buildingparser.stan
 cd data_utils
 python collect_indoor3d_data.py
 ```
-Processed data will save in `data/s3dis/stanford_indoor3d/`.
+Processed data will save in `data/stanford_indoor3d/`.
 ### Run
 ```
 ## Check model in ./models 

--- a/train_semseg.py
+++ b/train_semseg.py
@@ -88,7 +88,7 @@ def main(args):
     log_string('PARAMETER ...')
     log_string(args)
 
-    root = 'data/s3dis/stanford_indoor3d/'
+    root = 'data/stanford_indoor3d/'
     NUM_CLASSES = 13
     NUM_POINT = args.npoint
     BATCH_SIZE = args.batch_size


### PR DESCRIPTION
As mentioned in Line 12 of `collect_indoor3d_data.py`, the processed data is saved in `data/stanford_indoor3d` instead of `data/s3dis/stanford_indoor3d`